### PR TITLE
added case for missing config

### DIFF
--- a/lib/logger_exporter/backend.ex
+++ b/lib/logger_exporter/backend.ex
@@ -86,6 +86,12 @@ defmodule LoggerExporter.Backend do
     init(config, state)
   end
 
+  defp log_event(level, "MISSING_HOST"=msg, ts, md, state) do
+    event = format_event(level, msg, ts, md, state)
+
+    # Batcher.enqueue(event)
+  end
+
   defp log_event(level, msg, ts, md, state) do
     event = format_event(level, msg, ts, md, state)
 

--- a/lib/logger_exporter/config.ex
+++ b/lib/logger_exporter/config.ex
@@ -36,8 +36,8 @@ defmodule LoggerExporter.Config do
 
       :error ->
         raise ArgumentError,
-              "missing :host option for LoggerExporter application. " <>
-                "Expected an url"
+              "MISSING_HOST"
+
     end
   end
 


### PR DESCRIPTION
If config is missing, do not send event to Batcher.

This is the simplest I tried. If anything more needs to be done, let me know.